### PR TITLE
Use sparse matrix in push_relabel

### DIFF
--- a/src/push_relabel.jl
+++ b/src/push_relabel.jl
@@ -16,7 +16,7 @@ function push_relabel end
     ) where {T}
 
     n = lg.nv(residual_graph)
-    flow_matrix = zeros(T, n, n)
+    flow_matrix = spzeros(T, n, n)
 
     height = zeros(Int, n)
     height[source] = n


### PR DESCRIPTION
The push_relabel function creates a dense zeros matrix. This is very inefficient for sparse graphs. In my benchmarks, the `zeros` call took 30 seconds, afterwards it doesn't even show up any more. The total runtime for  `maximum_flow` also improves by a factor 10x.