### PR TITLE
Fix #40

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,11 +4,13 @@ authors = ["Mathieu Besançon <mathieu.besancon@gmail.com>"]
 version = "0.4.2"
 
 [deps]
+GLPK = "60bf3e95-4087-53dc-ae20-288a0d20c6a6"
 JuMP = "4076af6c-e467-56ae-b986-b466b2749572"
 LightGraphs = "093fc24a-ae57-5d10-9952-331d41423f4d"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
 SimpleTraits = "699a6c99-e7fa-54fc-8d76-47d257e15c1d"
+SimpleWeightedGraphs = "47aef6b3-ad0c-573a-a1e2-d07658019622"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]

--- a/src/LightGraphsFlows.jl
+++ b/src/LightGraphsFlows.jl
@@ -2,6 +2,8 @@ module LightGraphsFlows
 
 using LightGraphs
 const lg = LightGraphs
+using SimpleWeightedGraphs
+const swg = SimpleWeightedGraphs
 
 using SimpleTraits: @traitfn, @traitimpl
 import SimpleTraits

--- a/src/maximum_flow.jl
+++ b/src/maximum_flow.jl
@@ -67,6 +67,8 @@ is created.
 function residual end
 @traitfn residual(flow_graph::::lg.IsDirected) = lg.DiGraph(lg.Graph(flow_graph))
 
+residual(weighted_flow_graph::SimpleWeightedDiGraph) = residual(lg.SimpleDiGraph(weighted_flow_graph))
+
 # Method for Edmonds–Karp algorithm
 
 @traitfn function maximum_flow(
@@ -171,8 +173,12 @@ function maximum_flow(
         DefaultCapacity(flow_graph);
         algorithm::AbstractFlowAlgorithm  =    # keyword argument for algorithm
         PushRelabelAlgorithm(),
-        restriction::Real = 0                  # keyword argument for restriction max-flow
+        restriction::Real = 0,               # keyword argument for restriction max-flow
+        use_weights_as_capacity::Bool=false
     )
+    if use_weights_as_capacity
+        capacity_matrix = weights(flow_graph)
+    end
     if restriction > 0
         return maximum_flow(flow_graph, source, target, min.(restriction, capacity_matrix), algorithm)
     end

--- a/src/maximum_flow.jl
+++ b/src/maximum_flow.jl
@@ -67,7 +67,7 @@ is created.
 function residual end
 @traitfn residual(flow_graph::::lg.IsDirected) = lg.DiGraph(lg.Graph(flow_graph))
 
-residual(weighted_flow_graph::SimpleWeightedDiGraph) = residual(lg.SimpleDiGraph(weighted_flow_graph))
+residual(weighted_flow_graph::swg.SimpleWeightedDiGraph) = residual(lg.SimpleDiGraph(weighted_flow_graph))
 
 # Method for Edmonds–Karp algorithm
 

--- a/test/maximum_flow.jl
+++ b/test/maximum_flow.jl
@@ -53,5 +53,46 @@
                 @test maximum_flow(g, s, t, capacity_matrix, algorithm=ALGO(), restriction=caprestrict)[1] == frestrict
             end
         end
+
+        # Test specialization for weighted, where capacity is stored in edge weights
+        weighted_flow_graph = swg.SimpleWeightedDiGraph(nvertices)
+        for e in flow_edges
+            u, v, f = e
+            swg.add_edge!(weighted_flow_graph, u, v, f)
+        end
+
+        # Test all algorithms - type instability in PushRelabel #553
+        for ALGO in [EdmondsKarpAlgorithm, DinicAlgorithm, BoykovKolmogorovAlgorithm, PushRelabelAlgorithm]
+            @test maximum_flow(
+                weighted_flow_graph,
+                s,
+                t,
+                algorithm=ALGO(),
+                use_weights_as_capacity=true
+            )[1] == fcustom
+            @test maximum_flow(
+                weighted_flow_graph,
+                s,
+                t,
+                algorithm=ALGO(),
+                use_weights_as_capacity=false
+            )[1] != fcustom
+            @test maximum_flow(
+                weighted_flow_graph,
+                s,
+                t,
+                algorithm=ALGO(),
+                restriction=caprestrict,
+                use_weights_as_capacity=true
+            )[1] == frestrict
+            @test maximum_flow(
+                weighted_flow_graph,
+                s,
+                t,
+                algorithm=ALGO(),
+                restriction=caprestrict,
+                use_weights_as_capacity=false
+            )[1] != frestrict
+        end
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,6 +3,7 @@ using Test
 using LightGraphs
 import SimpleTraits
 const lg = LightGraphs
+const swg = SimpleWeightedGraphs
 
 using LinearAlgebra: diag
 using SparseArrays: spzeros

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,7 @@
 using LightGraphsFlows
 using Test
 using LightGraphs
+using SimpleWeightedGraphs
 import SimpleTraits
 const lg = LightGraphs
 const swg = SimpleWeightedGraphs


### PR DESCRIPTION
Hello there

As per @etienneINSA's request in #40  here is a specialization of the max-flow function for weighted graphs in which the capacities are equal to the weights. I'm not entirely confident it works well, since @simonschoelly's suggestion to simply use `weights(g)` instead of relying on `SimpleWeightedGraphs.jl` removed all the bugs without letting me understand them, but the small tests I added seem to suggest it's fine.

What do you think about the function signature? I would have used multiple dispatch instead of an additional argument but I didn't know how to detect weighted graphs without SWG.